### PR TITLE
Add skeleton Outlook-style app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# test_new
+# Outlook-style Performance Management App
+
+This repository contains a simple example of an Outlook-style performance management application.
+
+## Backend
+
+The backend is an Express server that provides a small set of task management APIs.
+
+```
+cd backend
+npm install
+npm start
+```
+
+The server exposes endpoints at `http://localhost:3001/tasks` for creating and retrieving tasks.
+
+## Frontend
+
+The frontend is a React application that displays tasks on a calendar.
+
+```
+cd frontend
+npm install
+npm start
+```
+
+The application fetches tasks from the backend and shows them using `react-big-calendar`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "license": "MIT",
+  "dependencies": {
+    "body-parser": "^1.20.2",
+    "cors": "^2.8.5",
+    "express": "^4.18.2"
+  },
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,40 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const cors = require('cors');
+
+const app = express();
+app.use(cors());
+app.use(bodyParser.json());
+
+let tasks = [];
+let nextId = 1;
+
+app.get('/tasks', (req, res) => {
+  res.json(tasks);
+});
+
+app.post('/tasks', (req, res) => {
+  const { title, owner, startDate, dueDate } = req.body;
+  const task = { id: nextId++, title, owner, startDate, dueDate, progress: 0 };
+  tasks.push(task);
+  res.status(201).json(task);
+});
+
+app.put('/tasks/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const index = tasks.findIndex(t => t.id === id);
+  if (index === -1) return res.status(404).send();
+  tasks[index] = { ...tasks[index], ...req.body };
+  res.json(tasks[index]);
+});
+
+app.delete('/tasks/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const index = tasks.findIndex(t => t.id === id);
+  if (index === -1) return res.status(404).send();
+  tasks.splice(index, 1);
+  res.status(204).send();
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "react-big-calendar": "^1.5.0",
+    "moment": "^2.29.4"
+  },
+  "scripts": {
+    "start": "react-scripts start"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>実績管理アプリ</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import { Calendar, momentLocalizer } from 'react-big-calendar';
+import moment from 'moment';
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+
+const localizer = momentLocalizer(moment);
+
+function App() {
+  const [events, setEvents] = useState([]);
+
+  useEffect(() => {
+    fetch('http://localhost:3001/tasks')
+      .then(res => res.json())
+      .then(data => {
+        setEvents(
+          data.map(task => ({
+            title: task.title,
+            start: new Date(task.startDate),
+            end: new Date(task.dueDate)
+          }))
+        );
+      });
+  }, []);
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>実績管理カレンダー</h1>
+      <Calendar
+        localizer={localizer}
+        events={events}
+        startAccessor="start"
+        endAccessor="end"
+        style={{ height: '80vh' }}
+      />
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- initialize frontend with React skeleton
- add backend Express server with in-memory tasks
- document how to start both projects

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_685154c982bc8333a609128d7c38db00